### PR TITLE
Added basic Text-to-Speech outbound call example

### DIFF
--- a/voice/make-an-outbound-call-ncco.go
+++ b/voice/make-an-outbound-call-ncco.go
@@ -13,11 +13,11 @@ func main() {
 	auth, _ := vonage.CreateAuthFromAppPrivateKey(APPLICATION_ID, privateKey)
 	client := vonage.NewVoiceClient(auth)
 
-	from := vonage.CallFrom{Type: "phone", Number: FROM_NUMBER}
+	from := vonage.CallFrom{Type: "phone", Number: VONAGE_NUMBER}
 	to := vonage.CallTo{Type: "phone", Number: TO_NUMBER}
 
 	MyNcco := ncco.Ncco{}
-	talk := ncco.TalkAction{Text: "This is the Go code snippets calling to say hello."}
+	talk := ncco.TalkAction{Text: "This is a text to speech call from Vonage"}
 	MyNcco.AddAction(talk)
 
 	// NCCO example

--- a/voice/text-to-speech-call.go
+++ b/voice/text-to-speech-call.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/vonage/vonage-go-sdk"
+	"github.com/vonage/vonage-go-sdk/ncco"
+)
+
+func main() {
+	privateKey, _ := ioutil.ReadFile(PATH_TO_PRIVATE_KEY_FILE)
+	auth, _ := vonage.CreateAuthFromAppPrivateKey(APPLICATION_ID, privateKey)
+	client := vonage.NewVoiceClient(auth)
+
+	from := vonage.CallFrom{Type: "phone", Number: FROM_NUMBER}
+	to := vonage.CallTo{Type: "phone", Number: TO_NUMBER}
+
+	MyNcco := ncco.Ncco{}
+	talk := ncco.TalkAction{Text: "This is the Go code snippets calling to say hello."}
+	MyNcco.AddAction(talk)
+
+	// NCCO example
+	result, _, _ := client.CreateCall(vonage.CreateCallOpts{From: from, To: to, Ncco: MyNcco})
+	// alternate version with answer URL
+	//result, _, _ := client.CreateCall(CreateCallOpts{From: from, To: to, AnswerUrl: []string{"https://example.com/answer"}})
+
+	fmt.Println(result.Uuid + " call ID started")
+}


### PR DESCRIPTION
I've added a new code snippet for making an outbound Text-To-Speech voice call. The example is almost a copy of the Go SDK example. Except I've replaced the string variables (from + to numbers and the application id into a placeholder to go with the location of the private key file) to hopefully be easier for people to read and understand which parts of the code they need to replace.